### PR TITLE
Add includeUserConfig option

### DIFF
--- a/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin.java
@@ -113,6 +113,7 @@ public class ScmSyncConfigurationPlugin extends Plugin{
     // when commit occurs
     private String commitMessagePattern = "[message]";
     private List<File> filesModifiedByLastReload;
+    private boolean includeUserConfig = true;
     private List<String> manualSynchronizationIncludes;
 
     public ScmSyncConfigurationPlugin(){
@@ -165,6 +166,7 @@ public class ScmSyncConfigurationPlugin extends Plugin{
         this.commitMessagePattern = pojo.getCommitMessagePattern();
         this.manualSynchronizationIncludes = pojo.getManualSynchronizationIncludes();
         this.business.setManualSynchronizationIncludes(manualSynchronizationIncludes);
+        this.includeUserConfig = pojo.isIncludeUserConfig();
     }
 
     protected void initialInit() throws Exception {
@@ -201,6 +203,7 @@ public class ScmSyncConfigurationPlugin extends Plugin{
         this.noUserCommitMessage = formData.getBoolean("noUserCommitMessage");
         this.displayStatus = formData.getBoolean("displayStatus");
         this.commitMessagePattern = req.getParameter("commitMessagePattern");
+        this.includeUserConfig = formData.getBoolean("includeUserConfig");
 
         String oldScmRepositoryUrl = this.scmRepositoryUrl;
         String scmType = req.getParameter("scm");
@@ -430,6 +433,10 @@ public class ScmSyncConfigurationPlugin extends Plugin{
 
     public boolean isDisplayStatus() {
         return displayStatus;
+    }
+
+    public boolean isIncludeUserConfig() {
+        return includeUserConfig;
     }
 
     public String getCommitMessagePattern() {

--- a/src/main/java/hudson/plugins/scm_sync_configuration/strategies/impl/UserConfigScmSyncStrategy.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/strategies/impl/UserConfigScmSyncStrategy.java
@@ -4,6 +4,7 @@ import hudson.XmlFile;
 import hudson.model.Item;
 import hudson.model.Saveable;
 import hudson.model.User;
+import hudson.plugins.scm_sync_configuration.ScmSyncConfigurationPlugin;
 import hudson.plugins.scm_sync_configuration.model.MessageWeight;
 import hudson.plugins.scm_sync_configuration.model.WeightedMessage;
 import hudson.plugins.scm_sync_configuration.strategies.AbstractScmSyncStrategy;
@@ -11,6 +12,7 @@ import hudson.plugins.scm_sync_configuration.strategies.model.ClassAndFileConfig
 import hudson.plugins.scm_sync_configuration.strategies.model.ConfigurationEntityMatcher;
 import hudson.plugins.scm_sync_configuration.strategies.model.PageMatcher;
 
+import java.io.File;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -32,6 +34,24 @@ public class UserConfigScmSyncStrategy extends AbstractScmSyncStrategy {
 
     public UserConfigScmSyncStrategy(){
         super(CONFIG_ENTITY_MATCHER, PAGE_MATCHERS);
+    }
+
+    @Override
+    public boolean isSaveableApplicable(Saveable saveable, File file) {
+        if(!ScmSyncConfigurationPlugin.getInstance().isIncludeUserConfig()){
+            return false;
+        } else {
+            return super.isSaveableApplicable(saveable, file);
+        }
+    }
+
+    @Override
+    public boolean isCurrentUrlApplicable(String url) {
+        if(!ScmSyncConfigurationPlugin.getInstance().isIncludeUserConfig()){
+            return false;
+        } else {
+            return super.isCurrentUrlApplicable(url);
+        }
     }
 
     @Override

--- a/src/main/java/hudson/plugins/scm_sync_configuration/xstream/ScmSyncConfigurationXStreamConverter.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/xstream/ScmSyncConfigurationXStreamConverter.java
@@ -85,6 +85,10 @@ public class ScmSyncConfigurationXStreamConverter implements Converter {
             writer.endNode();
         }
 
+        writer.startNode(AbstractMigrator.SCM_INCLUDE_USERCONFIG);
+        writer.setValue(Boolean.toString(plugin.isIncludeUserConfig()));
+        writer.endNode();
+
         if(plugin.getManualSynchronizationIncludes() != null){
             writer.startNode(AbstractMigrator.SCM_MANUAL_INCLUDES);
             for(String include : plugin.getManualSynchronizationIncludes()){

--- a/src/main/java/hudson/plugins/scm_sync_configuration/xstream/migration/AbstractMigrator.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/xstream/migration/AbstractMigrator.java
@@ -17,6 +17,7 @@ public abstract class AbstractMigrator<TFROM extends ScmSyncConfigurationPOJO, T
 	public static final String SCM_NO_USER_COMMIT_MESSAGE = "noUserCommitMessage";
     public static final String SCM_DISPLAY_STATUS = "displayStatus";
     public static final String SCM_COMMIT_MESSAGE_PATTERN = "commitMessagePattern";
+    public static final String SCM_INCLUDE_USERCONFIG = "includeUserConfig";
     public static final String SCM_MANUAL_INCLUDES = "manualSynchronizationIncludes";
 
     private static final Logger LOGGER = Logger.getLogger(AbstractMigrator.class.getName());
@@ -41,6 +42,7 @@ public abstract class AbstractMigrator<TFROM extends ScmSyncConfigurationPOJO, T
 		boolean noUserCommitMessage = false;
 		boolean displayStatus = true;
         String commitMessagePattern = "[message]";
+        boolean includeUserConfig = true;
         List<String> manualIncludes = null;
 		
 		while(reader.hasMoreChildren()){
@@ -56,6 +58,8 @@ public abstract class AbstractMigrator<TFROM extends ScmSyncConfigurationPOJO, T
 				scmContent = reader.getValue();
             } else if(SCM_COMMIT_MESSAGE_PATTERN.equals(reader.getNodeName())){
                 commitMessagePattern = reader.getValue();
+            } else if(SCM_INCLUDE_USERCONFIG.equals(reader.getNodeName())){
+                includeUserConfig = Boolean.parseBoolean(reader.getValue());
             } else if(SCM_MANUAL_INCLUDES.equals(reader.getNodeName())){
                 manualIncludes = new ArrayList<String>();
                 while(reader.hasMoreChildren()){
@@ -71,14 +75,15 @@ public abstract class AbstractMigrator<TFROM extends ScmSyncConfigurationPOJO, T
 			}
 			reader.moveUp();
 		}
-		
+
 		pojo.setScm(createSCMFrom(scmClassAttribute, scmContent));
 		pojo.setScmRepositoryUrl(scmRepositoryUrl);
 		pojo.setNoUserCommitMessage(noUserCommitMessage);
 		pojo.setDisplayStatus(displayStatus);
         pojo.setCommitMessagePattern(commitMessagePattern);
         pojo.setManualSynchronizationIncludes(manualIncludes);
-		
+        pojo.setIncludeUserConfig(includeUserConfig);
+
 		return pojo;
 	}
 	

--- a/src/main/java/hudson/plugins/scm_sync_configuration/xstream/migration/DefaultSSCPOJO.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/xstream/migration/DefaultSSCPOJO.java
@@ -11,6 +11,7 @@ public class DefaultSSCPOJO implements ScmSyncConfigurationPOJO {
 	private boolean noUserCommitMessage;
 	private boolean displayStatus;
     private String commitMessagePattern;
+    private boolean includeUserConfig;
     private List<String> manualSynchronizationIncludes;
 	
 	public String getScmRepositoryUrl() {
@@ -44,6 +45,14 @@ public class DefaultSSCPOJO implements ScmSyncConfigurationPOJO {
 
     public void setCommitMessagePattern(String commitMessagePattern) {
         this.commitMessagePattern = commitMessagePattern;
+    }
+
+    public boolean isIncludeUserConfig() {
+        return includeUserConfig;
+    }
+
+    public void setIncludeUserConfig(boolean includeUserConfig) {
+        this.includeUserConfig = includeUserConfig;
     }
 
     public void setManualSynchronizationIncludes(List<String> _manualSynchronizationIncludes){

--- a/src/main/java/hudson/plugins/scm_sync_configuration/xstream/migration/ScmSyncConfigurationPOJO.java
+++ b/src/main/java/hudson/plugins/scm_sync_configuration/xstream/migration/ScmSyncConfigurationPOJO.java
@@ -21,4 +21,6 @@ public interface ScmSyncConfigurationPOJO {
     public void setCommitMessagePattern(String commitMessagePattern);
     public List<String> getManualSynchronizationIncludes();
     public void setManualSynchronizationIncludes(List<String> manualSynchronizationIncludes);
+    public boolean isIncludeUserConfig();
+    public void setIncludeUserConfig(boolean includeUserConfig);
 }

--- a/src/main/resources/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin/config.jelly
+++ b/src/main/resources/hudson/plugins/scm_sync_configuration/ScmSyncConfigurationPlugin/config.jelly
@@ -34,6 +34,16 @@
         <f:textbox name="commitMessagePattern" value="${it.commitMessagePattern}" />
     </f:entry>
 
+    <f:entry title="${%Include user config}">
+        <j:choose>
+            <j:when test="${it.includeUserConfig}">
+                <f:checkbox name="includeUserConfig" checked="${it.includeUserConfig}" value="true" />
+            </j:when>
+            <j:otherwise>
+                <f:checkbox name="includeUserConfig" value="true" />
+            </j:otherwise>
+        </j:choose>
+    </f:entry>
     <!--
     Help url for manualSynchronizationIncludes field is a jelly script and not a html file
     because we need default includes list to be displayed in it !


### PR DESCRIPTION
When users are mostly managed through LDAP (or more precisely Active Directory)
there may be a lot of activity due to changes of the list of groups to which
someone belongs (often just changing the order). Moreover, this is not useful,
since the info is just always replaced with what's in AD.